### PR TITLE
Fix show more loop

### DIFF
--- a/zapread.com/Scripts/src/utility/loadmore.js
+++ b/zapread.com/Scripts/src/utility/loadmore.js
@@ -15,13 +15,13 @@ export function addposts(data, callback) {
 
 export function loadmore(options) {
     if (typeof options === 'undefined') {
-        options = { sort: 'Score', url: '/Home/InfiniteScroll/', blocknumber: 10, userId: -1 };
+        options = { sort: 'Score', url: '/Home/InfiniteScroll/', blocknumber: window.BlockNumber, userId: -1 };
     }
     if (typeof options.url === 'undefined') {
         options.url = '/Home/InfiniteScroll/';
     }
     if (typeof options.blocknumber === 'undefined') {
-        options.blocknumber = 10;
+        options.blocknumber = window.BlockNumber;
     }
     if (typeof options.sort === 'undefined') {
         options.sort = 'Score';


### PR DESCRIPTION
Show more only works once, this should fix it.

The blocknumber was always set to 10, luckily there was a variable counted up BlockNumber but one could also use something like `document.querySelectorAll('.social-feed-box').length`.